### PR TITLE
revert change to jurorStatus (fix klerosCounter.activeJurors)

### DIFF
--- a/src/KlerosLiquidMappings.ts
+++ b/src/KlerosLiquidMappings.ts
@@ -49,6 +49,8 @@ enum Period {
 export function handleStakeSet(event: StakeSetEvent): void {
   log.debug("handleSetStake: creating a new setStake", [])
 
+  let jurorStatus = checkJurorStatus(event.params._address, event.params._stake, event.params._newTotalStake, event.params._subcourtID)
+
   let entity = new StakeSet(
     event.transaction.hash.toHex() + "-" + event.logIndex.toString()
   )
@@ -63,7 +65,8 @@ export function handleStakeSet(event: StakeSetEvent): void {
   
   // update the juror entity and the courtStake
   updateJurorStake(event.params._address, event.params._subcourtID, event.params._stake,
-      event.params._newTotalStake, event.block.timestamp, event.block.number, event.transaction.hash, event.address)
+      event.params._newTotalStake, event.block.timestamp, event.block.number, event.transaction.hash,
+      jurorStatus, event.address)
 }
 
 export function handleDisputeCreation(event: DisputeCreationEvent): void {
@@ -569,7 +572,8 @@ function getOrCreateJuror(address: Address, courtID: BigInt | null, totalStake: 
 }
 
 function updateJurorStake(address: Address, courtID: BigInt,stake: BigInt, totalStaked: BigInt,
-                          timestamp: BigInt, blockNumber: BigInt, txID:Bytes, KLContract: Address): void{
+                          timestamp: BigInt, blockNumber: BigInt, txID:Bytes,
+                          jurorStatus:number, KLContract: Address): void{
   log.debug("updateJurorStake: updating court stake for juror {} and court {}", [address.toHexString(), courtID.toString()])
 
   let juror = getOrCreateJuror(address, courtID, totalStaked, KLContract)
@@ -584,8 +588,6 @@ function updateJurorStake(address: Address, courtID: BigInt,stake: BigInt, total
     // nothing to do
     return
   }
-
-  let jurorStatus = checkJurorStatus(address, stake, totalStaked, courtID)
 
   createOrUpdateCourtStake(courtID, stake, address, timestamp, blockNumber, txID, KLContract)
 


### PR DESCRIPTION
`checkJurorStatus` needs to be called before creating a new juror because it relies on a new juror being null to return 4 (very first time juror)

tests coming soon to prevent regressions